### PR TITLE
winrpm package name looks like it's lower case

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,7 +21,7 @@ end
     using WinRPM
     push!(WinRPM.sources, "http://download.opensuse.org/repositories/home:Luthaf/openSUSE_13.1/")
     WinRPM.update()
-    provides(WinRPM.RPM, "Chemharp", [libchemharp], os = :Windows, onload =
+    provides(WinRPM.RPM, "chemharp", [libchemharp], os = :Windows, onload =
     """
     function __init__()
         ENV["CHRP_MOLFILES"] = joinpath($(WinRPM.installdir), "lib", "molfiles")


### PR DESCRIPTION
Another issue in https://build.opensuse.org/package/view_file/home:Luthaf/mingw64-chemharp/mingw64-chemharp.spec?expand=1 is that dll's belong in bindir, not libdir. Not sure if your onload init hooks are going to work correctly here. Environment variables are not a great API for specifying runtime resource locations. Can the C library be initialized more directly?