### PR TITLE
test travis on both linux and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: julia
+os:
+  - linux
+  - osx
 julia:
   - nightly
 install:


### PR DESCRIPTION
this formerly needed to be explicitly enabled by an email to travis, see http://docs.travis-ci.com/user/multi-os/

but apparently now it's available by default ref https://github.com/travis-ci/docs-travis-ci-com/commit/8a4efe6e6bfb0dcce760eedabd2ffe640d6545d5